### PR TITLE
Add Docker packaging and optional SQLite tuning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+data/
+**/*.db
+**/*.sqlite
+**/*.log
+**/node_modules
+.git
+.github
+**/*.test
+**/*.out
+harvester

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TWITCH_TOKEN=oauth:replace-me
+GN_SQLITE_TUNING=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Download modules
+        run: go mod download
+      - name: Build
+        run: go build ./...
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker build .

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 # env / local config
 .env
 .env.*
+!.env.example
 
 elora.db
 *.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.23 AS builder
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/harvester ./cmd/harvester
+
+FROM gcr.io/distroless/base-debian12:nonroot
+WORKDIR /app
+COPY --from=builder /out/harvester /app/harvester
+
+EXPOSE 8765
+VOLUME ["/data"]
+
+USER nonroot
+
+ENTRYPOINT ["/app/harvester"]

--- a/README.md
+++ b/README.md
@@ -132,3 +132,22 @@ The same filters apply to `/messages`, `/count`, `/stream`, and `/ws`.
 
 These counters are useful while hammer-testing with `hey`, validating filters with `curl`,
 and monitoring production deployments.
+
+## Docker quick start
+
+```bash
+cp .env.example .env   # then edit TWITCH_TOKEN
+docker compose up --build
+curl -s localhost:8765/healthz
+```
+
+## SQLite tuning (optional)
+
+Set `GN_SQLITE_TUNING=1` to apply WAL mode, adjust synchronous and busy timeout, and
+increase mmap/temp_store settings on startup. The defaults remain unchanged when the
+variable is unset. Compose users can flip this via `.env`.
+
+## Integrating with elora-chat
+
+When running under Compose, other services can connect to gnasty via
+`http://gnasty:8765` on the shared network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 services:
   gnasty:
     build: .
-    command: 
-      - /app/harvester
+    entrypoint: ["/app/harvester"]
+    command:
       - -sqlite
       - /data/elora.db
       - -http-addr
       - :8765
+      - -youtube-url
+      - ${YOUTUBE_URL}
       - -twitch-channel
       - rifftrax
       - -twitch-nick
@@ -14,18 +16,13 @@ services:
       - -twitch-token
       - ${TWITCH_TOKEN}
       - -twitch-tls
-      - "true"
-      # -youtube-url
-      # https://www.youtube.com/watch?v=jfKfPfyJRdk
+      - ${TWITCH_TLS}
     environment:
-      - TWITCH_TOKEN=${TWITCH_TOKEN}
-      - GN_SQLITE_TUNING=${GN_SQLITE_TUNING-0}
-    ports:
-      - "8765:8765"
-    volumes:
-      - ./data:/data
-    networks:
-      - default
+      GN_SQLITE_TUNING: "${GN_SQLITE_TUNING-0}"
+      TWITCH_TOKEN: "${TWITCH_TOKEN}"
+    ports: ["8765:8765"]
+    volumes: ["./data:/data"]
+    networks: [default]
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  gnasty:
+    build: .
+    command: 
+      - /app/harvester
+      - -sqlite
+      - /data/elora.db
+      - -http-addr
+      - :8765
+      - -twitch-channel
+      - rifftrax
+      - -twitch-nick
+      - hp_az
+      - -twitch-token
+      - ${TWITCH_TOKEN}
+      - -twitch-tls
+      - "true"
+      # -youtube-url
+      # https://www.youtube.com/watch?v=jfKfPfyJRdk
+    environment:
+      - TWITCH_TOKEN=${TWITCH_TOKEN}
+      - GN_SQLITE_TUNING=${GN_SQLITE_TUNING-0}
+    ports:
+      - "8765:8765"
+    volumes:
+      - ./data:/data
+    networks:
+      - default
+
+networks:
+  default:
+    name: gnasty-chat

--- a/internal/sink/sqlite.go
+++ b/internal/sink/sqlite.go
@@ -47,6 +47,7 @@ func OpenSQLite(path string) (*SQLiteSink, error) {
 		_ = db.Close()
 		return nil, errors.Wrap(err, "set WAL")
 	}
+	ApplySQLitePragmas(context.Background(), db)
 	return &SQLiteSink{db: db}, nil
 }
 

--- a/internal/sink/sqlite_pragma.go
+++ b/internal/sink/sqlite_pragma.go
@@ -1,0 +1,50 @@
+package sink
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log"
+	"os"
+)
+
+// ApplySQLitePragmas applies optional SQLite tuning statements when enabled via the
+// GN_SQLITE_TUNING environment variable. Each pragma result is logged at info
+// level.
+func ApplySQLitePragmas(ctx context.Context, db *sql.DB) {
+	if os.Getenv("GN_SQLITE_TUNING") != "1" {
+		return
+	}
+
+	pragmas := []string{
+		"PRAGMA journal_mode=WAL;",
+		"PRAGMA synchronous=NORMAL;",
+		"PRAGMA busy_timeout=5000;",
+		"PRAGMA wal_autocheckpoint=1000;",
+		"PRAGMA temp_store=MEMORY;",
+		"PRAGMA mmap_size=268435456;",
+	}
+
+	for _, pragma := range pragmas {
+		if value, err := applyPragma(ctx, db, pragma); err != nil {
+			log.Printf("sqlite: pragma %s failed: %v", pragma, err)
+		} else {
+			log.Printf("sqlite: pragma %s => %v", pragma, value)
+		}
+	}
+}
+
+func applyPragma(ctx context.Context, db *sql.DB, pragma string) (any, error) {
+	row := db.QueryRowContext(ctx, pragma)
+	var value any
+	if err := row.Scan(&value); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			if _, execErr := db.ExecContext(ctx, pragma); execErr != nil {
+				return nil, execErr
+			}
+			return "ok", nil
+		}
+		return nil, err
+	}
+	return value, nil
+}


### PR DESCRIPTION
## Summary
- add a multi-stage distroless Dockerfile plus compose file and ignore list for containerized runs
- add GitHub Actions workflow to compile the Go project and build the Docker image on CI
- add opt-in SQLite pragma helper gated by GN_SQLITE_TUNING and document Docker usage

## Testing
- go build ./...

## Manual test script
```bash
# 1) local build
go build ./...

# 2) docker
docker build -t gnasty-chat:dev .

# 3) compose (edit .env first)
cp .env.example .env
# put a valid twitch token in .env if you want live data; otherwise omit twitch flags in compose command
docker compose up --build -d
sleep 2

# 4) probes
curl -s localhost:8765/healthz
curl -I -H 'Accept-Encoding: gzip' http://localhost:8765/count
curl --compressed 'http://localhost:8765/messages?limit=3'
curl -N http://localhost:8765/stream | head -n 10

# 5) optional: toggle PRAGMAs
docker compose down
sed -i 's/GN_SQLITE_TUNING=0/GN_SQLITE_TUNING=1/' .env
docker compose up --build -d
docker exec -it $(docker ps -qf name=gnasty) sh -lc "sqlite3 /data/elora.db 'PRAGMA journal_mode;'"
```

------
https://chatgpt.com/codex/tasks/task_e_68db298169e08322be2579b5b41576c6